### PR TITLE
Lock while iterating conns

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -117,7 +117,7 @@ func (d *PacketFilter) loop() {
 		}
 
 		d.mut.Lock()
-		sent := d.sendPaketLocked(pkt)
+		sent := d.sendPacketLocked(pkt)
 		d.mut.Unlock()
 		if !sent {
 			atomic.AddUint64(&d.dropped, 1)
@@ -126,7 +126,7 @@ func (d *PacketFilter) loop() {
 	}
 }
 
-func (d *PacketFilter) sendPaketLocked(pkt packet) bool {
+func (d *PacketFilter) sendPacketLocked(pkt packet) bool {
 	for _, conn := range d.conns {
 		if conn.filter == nil || conn.filter.ClaimIncoming(pkt.buf, pkt.addr) {
 			select {

--- a/filter.go
+++ b/filter.go
@@ -93,7 +93,6 @@ func (d *PacketFilter) Start() {
 
 func (d *PacketFilter) loop() {
 	var buf []byte
-next:
 	for {
 		buf = bufPool.Get().([]byte)
 		n, addr, err := d.conn.ReadFrom(buf)
@@ -104,33 +103,39 @@ next:
 			buf:  buf[:n],
 		}
 
-		d.mut.Lock()
-		conns := d.conns
-		d.mut.Unlock()
-
 		if err != nil {
-			for _, conn := range conns {
+			d.mut.Lock()
+			for _, conn := range d.conns {
 				select {
 				case conn.recvBuffer <- pkt:
 				default:
 					atomic.AddUint64(&d.overflow, 1)
 				}
 			}
+			d.mut.Unlock()
 			return
 		}
 
-		for _, conn := range conns {
-			if conn.filter == nil || conn.filter.ClaimIncoming(pkt.buf, pkt.addr) {
-				select {
-				case conn.recvBuffer <- pkt:
-				default:
-					bufPool.Put(pkt.buf[:maxPacketSize])
-					atomic.AddUint64(&d.overflow, 1)
-				}
-				goto next
-			}
+		d.mut.Lock()
+		sent := d.sendPaketLocked(pkt)
+		d.mut.Unlock()
+		if !sent {
+			atomic.AddUint64(&d.dropped, 1)
 		}
 		bufPool.Put(pkt.buf[:maxPacketSize])
-		atomic.AddUint64(&d.dropped, 1)
 	}
+}
+
+func (d *PacketFilter) sendPaketLocked(pkt packet) bool {
+	for _, conn := range d.conns {
+		if conn.filter == nil || conn.filter.ClaimIncoming(pkt.buf, pkt.addr) {
+			select {
+			case conn.recvBuffer <- pkt:
+			default:
+				atomic.AddUint64(&d.overflow, 1)
+			}
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Addresses a panic in L114 of filter.go: https://sentry.syncthing.net/share/issue/95994db5cc04489dad325034dac269e5/

Just getting the slice under lock isn't enough, the slice is still shared.  

I refactored to have a single point to lock-unlock, i.e. not having to unlock in any goto/continue paths.